### PR TITLE
Add sprint report tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Go-based MCP (Model Control Protocol) connector for Jira that enables AI assis
 - Add and retrieve comments
 - Add worklogs to issues
 - List and manage sprints
+- Generate sprint reports
 - Retrieve issue history and relationships
 - Link issues and get related issues
 - Transition issues through workflows

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 	tools.RegisterJiraIssueTool(mcpServer)
 	tools.RegisterJiraSearchTool(mcpServer)
 	tools.RegisterJiraSprintTool(mcpServer)
+	tools.RegisterJiraSprintReportTool(mcpServer)
 	tools.RegisterJiraStatusTool(mcpServer)
 	tools.RegisterJiraTransitionTool(mcpServer)
 	tools.RegisterJiraWorklogTool(mcpServer)
@@ -66,4 +67,3 @@ func main() {
 		}
 	}
 }
-

--- a/tools/jira_sprint_report.go
+++ b/tools/jira_sprint_report.go
@@ -1,0 +1,130 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/nguyenvanduocit/jira-mcp/services"
+	"github.com/nguyenvanduocit/jira-mcp/util"
+)
+
+func RegisterJiraSprintReportTool(s *server.MCPServer) {
+	reportTool := mcp.NewTool("sprint_report",
+		mcp.WithDescription("Generate a summary report for a Jira sprint including story points, bug count and a burndown table"),
+		mcp.WithString("sprint_id", mcp.Required(), mcp.Description("Numeric ID of the sprint")),
+	)
+	s.AddTool(reportTool, util.ErrorGuard(jiraSprintReportHandler))
+}
+
+func jiraSprintReportHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	sprintIDStr, ok := request.Params.Arguments["sprint_id"].(string)
+	if !ok {
+		return nil, fmt.Errorf("sprint_id argument is required")
+	}
+
+	sprintID, err := strconv.Atoi(sprintIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid sprint_id: %v", err)
+	}
+
+	sprint, response, err := services.AgileClient().Sprint.Get(ctx, sprintID)
+	if err != nil {
+		if response != nil {
+			return nil, fmt.Errorf("failed to get sprint: %s (endpoint: %s)", response.Bytes.String(), response.Endpoint)
+		}
+		return nil, fmt.Errorf("failed to get sprint: %v", err)
+	}
+
+	// Fetch all issues in the sprint with changelog expanded for story points
+	boardID := sprint.OriginBoardID
+	opts := &models.IssueOptionScheme{Expand: []string{"changelog"}}
+	page, resp, err := services.AgileClient().Board.IssuesBySprint(ctx, boardID, sprintID, opts, 0, 50)
+	if err != nil {
+		if resp != nil {
+			return nil, fmt.Errorf("failed to get sprint issues: %s (endpoint: %s)", resp.Bytes.String(), resp.Endpoint)
+		}
+		return nil, fmt.Errorf("failed to get sprint issues: %v", err)
+	}
+
+	totalPoints := 0.0
+	bugCount := 0
+
+	// Map date string -> points remaining
+	burnData := make(map[string]float64)
+
+	for _, issue := range page.Issues {
+		if issue.Fields != nil && issue.Fields.IssueType != nil && issue.Fields.IssueType.Name == "Bug" {
+			bugCount++
+		}
+
+		points := extractStoryPoints(issue)
+		totalPoints += points
+
+		doneDate := extractDoneDate(issue)
+		if !doneDate.IsZero() {
+			dateKey := doneDate.Format("2006-01-02")
+			burnData[dateKey] += points
+		}
+	}
+
+	// Build burndown table from sprint start to end
+	burnTable := make([]string, 0)
+	remaining := totalPoints
+	start := sprint.StartDate
+	end := sprint.EndDate
+	for d := start; !d.After(end); d = d.Add(24 * time.Hour) {
+		day := d.Format("2006-01-02")
+		if val, ok := burnData[day]; ok {
+			remaining -= val
+			if remaining < 0 {
+				remaining = 0
+			}
+		}
+		burnTable = append(burnTable, fmt.Sprintf("%s: %.1f", day, remaining))
+	}
+
+	result := fmt.Sprintf(`Sprint Report\nName: %s\nState: %s\nTotal Points: %.1f\nBug Count: %d\n\nBurndown:\n%s`,
+		sprint.Name, sprint.State, totalPoints, bugCount, strings.Join(burnTable, "\n"))
+
+	return mcp.NewToolResultText(result), nil
+}
+
+func extractStoryPoints(issue *models.IssueSchemeV2) float64 {
+	var points float64
+	if issue.Changelog != nil && issue.Changelog.Histories != nil {
+		for _, h := range issue.Changelog.Histories {
+			for _, item := range h.Items {
+				if item.Field == "Story point estimate" && item.ToString != "" {
+					p, err := strconv.ParseFloat(item.ToString, 64)
+					if err == nil {
+						points = p
+					}
+				}
+			}
+		}
+	}
+	return points
+}
+
+func extractDoneDate(issue *models.IssueSchemeV2) time.Time {
+	if issue.Changelog == nil || issue.Changelog.Histories == nil {
+		return time.Time{}
+	}
+	for _, h := range issue.Changelog.Histories {
+		for _, item := range h.Items {
+			if item.Field == "status" && (item.ToString == "Done" || item.ToString == "Closed" || item.ToString == "Resolved") {
+				t, err := time.Parse(time.RFC3339, h.Created)
+				if err == nil {
+					return t
+				}
+			}
+		}
+	}
+	return time.Time{}
+}

--- a/tools/jira_sprint_report_test.go
+++ b/tools/jira_sprint_report_test.go
@@ -1,0 +1,37 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestJiraSprintReportHandler(t *testing.T) {
+	sprintID := os.Getenv("TEST_SPRINT_ID")
+	if sprintID == "" {
+		t.Skip("TEST_SPRINT_ID not set")
+	}
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]interface{}{"sprint_id": sprintID}
+
+	res, err := jiraSprintReportHandler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || len(res.Content) == 0 {
+		t.Fatal("empty result")
+	}
+
+	textContent, ok := res.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("unexpected content type: %T", res.Content[0])
+	}
+
+	if !strings.Contains(textContent.Text, "Sprint Report") {
+		t.Errorf("result missing Sprint Report header: %s", textContent.Text)
+	}
+}


### PR DESCRIPTION
## Summary
- add sprint report tool to generate story point totals, bug counts and a burndown table
- register the new tool in main server setup
- document sprint reporting capability in README
- add test for sprint report handler using `TEST_SPRINT_ID`

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842528e9a00832b8429251a0a6899a1