### PR TITLE
fix: render ADF comment body as readable text in jira_get_comments tool

### DIFF
--- a/tools/jira_comment.go
+++ b/tools/jira_comment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/nguyenvanduocit/jira-mcp/services"
+	"github.com/nguyenvanduocit/jira-mcp/util"
 )
 
 // Input types for typed tools
@@ -97,12 +98,15 @@ func jiraGetCommentsHandler(ctx context.Context, request mcp.CallToolRequest, in
 			authorName = comment.Author.DisplayName
 		}
 
-		result += fmt.Sprintf("ID: %s\nAuthor: %s\nCreated: %s\nUpdated: %s\nBody: %s\n\n",
+		// Render ADF body to readable text
+		bodyText := util.RenderADF(comment.Body)
+
+		result += fmt.Sprintf("ID: %s\nAuthor: %s\nCreated: %s\nUpdated: %s\nBody:\n%s\n\n",
 			comment.ID,
 			authorName,
 			comment.Created,
 			comment.Updated,
-			comment.Body)
+			bodyText)
 	}
 
 	return mcp.NewToolResultText(result), nil


### PR DESCRIPTION
The jira_get_comments tool was returning raw Atlassian Document Format (ADF) JSON structure instead of human-readable formatted text, making comments difficult to read and understand.

Changes:
- Import util package in tools/jira_comment.go
- Use util.RenderADF() to convert ADF structure to markdown format
- Improve output formatting by placing "Body:" on separate line
- Ensure consistent behavior with other tools that handle ADF content

This fixes the readability issue while maintaining all existing functionality and follows the same pattern used in jira_get_issue tool for description formatting.